### PR TITLE
Move follow-up configuration from FOLLOW_UPS to RQAS

### DIFF
--- a/configurations/full_pipeline_config.json
+++ b/configurations/full_pipeline_config.json
@@ -38,17 +38,18 @@
     "mag_s01e17_activation",
     "mag_s01e18_activation",
     "mag_s01e19_activation",
-    "mag_s01e20_activation"
+    "mag_s01e20_activation",
 
+    "imaqal_s01_follow_up_w2",
+    "mag_s01_w8_follow_up",
+    "mag_s01_w10_follow_up",
+    "mag_s01_w18_follow_up"
   ],
   "DemogFlowNames":[
     "imaqal_demog"
   ],
   "FollowUpFlowNames":[
-    "imaqal_s01_follow_up_w2",
-    "mag_s01_w8_follow_up",
-    "mag_s01_w10_follow_up",
-    "mag_s01_w18_follow_up"
+
   ],
   "RapidProKeyRemappings": [
     {"RapidProKey": "avf_phone_id", "PipelineKey": "uid"},

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -507,7 +507,7 @@ class PipelineConfiguration(object):
     # TODO: Add Q6 to the full pipeline RQA coding plans, by uncommenting the following:
     # FULL_PIPELINE_RQA_CODING_PLANS += Q6_RQA_CODING_PLANS
 
-    FOLLOW_UP_CODING_PLANS = [
+    FULL_PIPELINE_RQA_CODING_PLANS += [
         CodingPlan(raw_field="women_participation_raw",
                    coded_field="women_participation_coded",
                    time_field="sent_on",
@@ -563,6 +563,10 @@ class PipelineConfiguration(object):
                    binary_code_scheme=CodeSchemes.DECISIONS_MINORITY_CLAN_YES_NO_AMB,
                    binary_coded_field="decisions_minority_clan_yes_no_amb_coded",
                    binary_analysis_file_key="decisions_minority_clan_yes_no_amb")
+    ]
+
+    FOLLOW_UP_CODING_PLANS = [
+
     ]
 
     LOCATION_CODING_PLANS = [


### PR DESCRIPTION
A relatively low risk method of treating the follow-ups as RQAS. Compare with an alternative implementation at #103.

Note that this works with the the full pipeline only.