### PR TITLE
Only delete successful containers

### DIFF
--- a/docker-run-fetch-raw-data.sh
+++ b/docker-run-fetch-raw-data.sh
@@ -47,12 +47,6 @@ CMD="pipenv run $PROFILE_CPU_CMD python -u fetch_raw_data.py \
 "
 container="$(docker container create ${SYS_PTRACE_CAPABILITY} -w /app "$IMAGE_NAME" /bin/bash -c "$CMD")"
 
-function finish {
-    # Tear down the container when done.
-    docker container rm "$container" >/dev/null
-}
-trap finish EXIT
-
 # Copy input data into the container
 docker cp "$GOOGLE_CLOUD_CREDENTIALS_FILE_PATH" "$container:/credentials/google-cloud-credentials.json"
 docker cp "$PIPELINE_CONFIGURATION" "$container:/data/pipeline-configuration.json"
@@ -69,3 +63,6 @@ if [[ "$PROFILE_CPU" = true ]]; then
     mkdir -p "$(dirname "$CPU_PROFILE_OUTPUT_PATH")"
     docker cp "$container:/data/cpu.prof" "$CPU_PROFILE_OUTPUT_PATH"
 fi
+
+# Tear down the container, now that all expected output files have been copied out successfully
+docker container rm "$container" >/dev/null

--- a/docker-run-fetch-recovered-data.sh
+++ b/docker-run-fetch-recovered-data.sh
@@ -48,12 +48,6 @@ CMD="pipenv run $PROFILE_CPU_CMD python -u fetch_recovered_data.py \
 "
 container="$(docker container create ${SYS_PTRACE_CAPABILITY} -w /app "$IMAGE_NAME" /bin/bash -c "$CMD")"
 
-function finish {
-    # Tear down the container when done.
-    docker container rm "$container" >/dev/null
-}
-trap finish EXIT
-
 # Copy input data into the container
 docker cp "$GOOGLE_CLOUD_CREDENTIALS_FILE_PATH" "$container:/credentials/google-cloud-credentials.json"
 docker cp "$PIPELINE_CONFIGURATION" "$container:/data/pipeline-configuration.json"
@@ -70,3 +64,6 @@ if [[ "$PROFILE_CPU" = true ]]; then
     mkdir -p "$(dirname "$CPU_PROFILE_OUTPUT_PATH")"
     docker cp "$container:/data/cpu.prof" "$CPU_PROFILE_OUTPUT_PATH"
 fi
+
+# Tear down the container, now that all expected output files have been copied out successfully
+docker container rm "$container" >/dev/null

--- a/docker-run-generate-outputs.sh
+++ b/docker-run-generate-outputs.sh
@@ -72,12 +72,6 @@ CMD="pipenv run $PROFILE_CPU_CMD $PROFILE_MEMORY_CMD python -u generate_outputs.
 "
 container="$(docker container create ${SYS_PTRACE_CAPABILITY} -w /app "$IMAGE_NAME" /bin/bash -c "$CMD")"
 
-function finish {
-    # Tear down the container when done.
-    docker container rm "$container" >/dev/null
-}
-trap finish EXIT
-
 # Copy input data into the container
 docker cp "$GOOGLE_CLOUD_CREDENTIALS_FILE_PATH" "$container:/credentials/google-cloud-credentials.json"
 docker cp "$PIPELINE_CONFIGURATION" "$container:/data/pipeline_configuration.json"
@@ -143,3 +137,6 @@ if [[ "$PROFILE_MEMORY" = true ]]; then
     mkdir -p "$(dirname "$MEMORY_PROFILE_OUTPUT_PATH")"
     docker cp "$container:/data/memory.prof" "$MEMORY_PROFILE_OUTPUT_PATH"
 fi
+
+# Tear down the container, now that all expected output files have been copied out successfully
+docker container rm "$container" >/dev/null


### PR DESCRIPTION
Automatically deleting containers when they complete is a nice piece of housekeeping that keeps disk usage low and means we don't have to remember to remove containers we definitely don't need anymore (once a container has run successfully I don't think we've ever had a future use for it). However, it's super annoying if it deletes early because we don't get a chance to get any useful data out of it.

This updates to only delete containers if they ran correctly and we managed to copy all the data out of them that we expected to be able to copy out, which we've been doing on CSAP for some time. Not all the docker-run scripts needed updating: those that were more recently adapted from CSAP projects already have these in this repo.